### PR TITLE
feat: Interactive tmux-based sessions with transcript streaming

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ export const config = {
 
 /**
  * Agent presets -- common command + args combos.
+ * Model names must match LiteLLM proxy aliases (10.71.1.33:4000).
  */
 export const presets: Record<string, { command: string; args: string[] }> = {
   claude: {
@@ -21,11 +22,11 @@ export const presets: Record<string, { command: string; args: string[] }> = {
   },
   "claude-sonnet": {
     command: "claude",
-    args: ["--print", "--permission-mode", "bypassPermissions", "--model", "claude-sonnet-4-20250514"],
+    args: ["--print", "--permission-mode", "bypassPermissions", "--model", "sonnet"],
   },
   "claude-opus": {
     command: "claude",
-    args: ["--print", "--permission-mode", "bypassPermissions", "--model", "claude-opus-4-0520"],
+    args: ["--print", "--permission-mode", "bypassPermissions", "--model", "opus"],
   },
   codex: {
     command: "codex",
@@ -34,5 +35,17 @@ export const presets: Record<string, { command: string; args: string[] }> = {
   "codex-auto": {
     command: "codex",
     args: ["exec", "--full-auto"],
+  },
+  "claude-interactive": {
+    command: "claude",
+    args: ["--permission-mode", "bypassPermissions"],
+  },
+  "claude-interactive-sonnet": {
+    command: "claude",
+    args: ["--permission-mode", "bypassPermissions", "--model", "sonnet"],
+  },
+  "claude-interactive-opus": {
+    command: "claude",
+    args: ["--permission-mode", "bypassPermissions", "--model", "opus"],
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,12 @@ import { Hono } from "hono";
 import { config } from "./config";
 import {
   createSession,
+  createInteractiveSession,
   listSessions,
   getSession,
   killSession,
   sendInput,
+  readTranscript,
   addWsClient,
   removeWsClient,
   sessionExists,
@@ -49,14 +51,25 @@ app.get("/health", (c) => c.json({ ok: true }));
 
 // ---------------------------------------------------------------------------
 // POST /sessions -- spawn a new session
+// Body: { task, mode?: "print" | "interactive", ...SessionCreateOpts }
 // ---------------------------------------------------------------------------
 app.post("/sessions", async (c) => {
   try {
-    const body = await c.req.json();
+    const body = await c.req.json<{ task: string; mode?: string } & Record<string, unknown>>();
     if (!body.task) {
       return c.json({ error: "task is required" }, 400);
     }
-    const session = createSession(body);
+
+    const mode = body.mode ?? "print";
+    if (mode !== "print" && mode !== "interactive") {
+      return c.json({ error: 'mode must be "print" or "interactive"' }, 400);
+    }
+
+    const session =
+      mode === "interactive"
+        ? await createInteractiveSession(body as any)
+        : createSession(body as any);
+
     return c.json(session, 201);
   } catch (err: any) {
     return c.json({ error: err.message }, 400);
@@ -73,8 +86,8 @@ app.get("/sessions", (c) => {
 // ---------------------------------------------------------------------------
 // GET /sessions/:id -- session detail with recent output
 // ---------------------------------------------------------------------------
-app.get("/sessions/:id", (c) => {
-  const session = getSession(c.req.param("id"));
+app.get("/sessions/:id", async (c) => {
+  const session = await getSession(c.req.param("id"));
   if (!session) return c.json({ error: "Not found" }, 404);
   return c.json(session);
 });
@@ -89,7 +102,7 @@ app.delete("/sessions/:id", (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// POST /sessions/:id/input -- send stdin
+// POST /sessions/:id/input -- send input (stdin or tmux send-keys)
 // ---------------------------------------------------------------------------
 app.post("/sessions/:id/input", async (c) => {
   const body = await c.req.json<{ input: string }>();
@@ -101,25 +114,50 @@ app.post("/sessions/:id/input", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
+// GET /sessions/:id/transcript -- read transcript file (interactive only)
+// Query: ?since=<byte-offset>  (omit for full transcript)
+// ---------------------------------------------------------------------------
+app.get("/sessions/:id/transcript", async (c) => {
+  const sinceParam = c.req.query("since");
+  const since = sinceParam !== undefined ? parseInt(sinceParam, 10) : undefined;
+
+  const text = await readTranscript(c.req.param("id"), since);
+  if (text === null) {
+    return c.json(
+      { error: "Not found or session has no transcript (print-mode sessions do not produce transcripts)" },
+      404
+    );
+  }
+
+  return new Response(text, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "x-transcript-length": String(text.length),
+    },
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Bun.serve with WebSocket support
 // ---------------------------------------------------------------------------
 
 const banner = `
-  🐒 monkeyproof v0.1.0
-  ──────────────────────────────────────
+  monkeyproof v0.1.0
+  ──────────────────────────────────────────────
   Port:     ${config.port}
   Max:      ${config.maxSessions} sessions
   Buffer:   ${config.outputBufferSize} lines
   TTL:      ${config.sessionTtlMs / 1000}s
-  ──────────────────────────────────────
-  POST   /sessions          → spawn
-  GET    /sessions          → list
-  GET    /sessions/:id      → detail
-  DELETE /sessions/:id      → kill
-  POST   /sessions/:id/input → stdin
-  WS     /sessions/:id/ws   → stream
-  ──────────────────────────────────────
-  Trust the awesomeness.
+  ──────────────────────────────────────────────
+  POST   /sessions                → spawn
+  GET    /sessions                → list
+  GET    /sessions/:id            → detail
+  DELETE /sessions/:id            → kill
+  POST   /sessions/:id/input      → send input
+  GET    /sessions/:id/transcript → transcript (interactive)
+  WS     /sessions/:id/ws         → stream
+  ──────────────────────────────────────────────
+  Modes: print (default) | interactive (tmux)
 `;
 
 console.log(banner);
@@ -132,19 +170,18 @@ Bun.serve({
     // WebSocket upgrade for /sessions/:id/ws
     const wsMatch = url.pathname.match(/^\/sessions\/([^/]+)\/ws$/);
     if (wsMatch && req.headers.get("upgrade") === "websocket") {
-      const sessionId = wsMatch[1];
+      const sessionId = wsMatch[1]!;
 
       if (!sessionExists(sessionId)) {
         return new Response("Session not found", { status: 404 });
       }
 
-      // Auth via query param for WS
       const token = url.searchParams.get("token");
       if (token !== config.authToken) {
         return new Response("Unauthorized", { status: 401 });
       }
 
-      const success = server.upgrade(req, { data: { sessionId } });
+      const success = server.upgrade(req, { data: { sessionId } } as any);
       if (success) return undefined;
       return new Response("WebSocket upgrade failed", { status: 500 });
     }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,6 +1,9 @@
 /**
  * @module sessions
  * @description Session manager -- spawns, tracks, and streams coding agent processes.
+ * Supports two modes:
+ *   - "print": one-shot subprocess with piped stdout (original behavior)
+ *   - "interactive": tmux-based persistent session with live capture
  */
 
 import { spawn, type Subprocess } from "bun";
@@ -26,6 +29,7 @@ export interface SessionInfo {
   task: string;
   cwd: string;
   command: string;
+  type: "print" | "interactive";
   status: "running" | "exited" | "killed";
   exitCode: number | null;
   pid: number | null;
@@ -37,6 +41,7 @@ export interface SessionInfo {
 
 export interface SessionDetail extends SessionInfo {
   recentOutput: string;
+  transcriptPath: string | null;
 }
 
 interface Session {
@@ -44,7 +49,15 @@ interface Session {
   task: string;
   cwd: string;
   command: string;
-  proc: Subprocess;
+  type: "print" | "interactive";
+  // print-only
+  proc?: Subprocess;
+  // interactive-only
+  tmuxName?: string;
+  transcriptPath?: string;
+  _pollTimer?: ReturnType<typeof setInterval>;
+  _lastCapturedLength: number;
+  // shared
   status: "running" | "exited" | "killed";
   exitCode: number | null;
   createdAt: Date;
@@ -79,7 +92,7 @@ setInterval(() => {
 }, 60_000);
 
 // ---------------------------------------------------------------------------
-// Create
+// Create -- print mode (one-shot subprocess)
 // ---------------------------------------------------------------------------
 
 export function createSession(opts: SessionCreateOpts): SessionInfo {
@@ -95,12 +108,11 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
   const id = randomUUID().slice(0, 8);
   const cwd = opts.cwd || process.env.HOME || "/tmp";
 
-  // Resolve command + args from preset or explicit
   let command: string;
   let args: string[];
 
   if (opts.preset && presets[opts.preset]) {
-    const preset = presets[opts.preset];
+    const preset = presets[opts.preset]!;
     command = preset.command;
     args = [...preset.args];
   } else {
@@ -108,15 +120,12 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
     args = opts.args || ["--print", "--permission-mode", "bypassPermissions"];
   }
 
-  // Add max-turns for claude
   if (command === "claude" && opts.maxTurns) {
     args.push("--max-turns", String(opts.maxTurns));
   }
 
-  // Append the task as the final argument
   args.push(opts.task);
 
-  // Build env
   const procEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),
     ...opts.env,
@@ -134,7 +143,9 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
     task: opts.task.slice(0, 500),
     cwd,
     command: `${command} ${args.slice(0, -1).join(" ")}`,
+    type: "print",
     proc,
+    _lastCapturedLength: 0,
     status: "running",
     exitCode: null,
     createdAt: new Date(),
@@ -145,17 +156,14 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
 
   sessions.set(id, session);
 
-  // Stream stdout
   streamReader(session, proc.stdout, "stdout");
   streamReader(session, proc.stderr, "stderr");
 
-  // Handle exit
   proc.exited.then((code) => {
     session.status = "exited";
     session.exitCode = code;
     session.endedAt = new Date();
     broadcast(session, { type: "exit", code, duration: getDuration(session) });
-    // Close WS clients after a short delay (let them receive the exit message)
     setTimeout(() => {
       for (const ws of session.wsClients) {
         try {
@@ -169,6 +177,90 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
 }
 
 // ---------------------------------------------------------------------------
+// Create -- interactive mode (tmux session)
+// ---------------------------------------------------------------------------
+
+export async function createInteractiveSession(
+  opts: SessionCreateOpts
+): Promise<SessionInfo> {
+  if (sessions.size >= config.maxSessions) {
+    const running = Array.from(sessions.values()).filter(
+      (s) => s.status === "running"
+    ).length;
+    throw new Error(
+      `Max sessions reached (${config.maxSessions}). ${running} running.`
+    );
+  }
+
+  const id = randomUUID().slice(0, 8);
+  const cwd = opts.cwd || process.env.HOME || "/tmp";
+  const tmuxName = `mp-${id}`;
+
+  // Resolve command + args (strip --print if present)
+  let claudeArgs: string[];
+  if (opts.preset && presets[opts.preset]) {
+    claudeArgs = [...presets[opts.preset]!.args];
+  } else if (opts.args) {
+    claudeArgs = [...opts.args];
+  } else {
+    claudeArgs = ["--permission-mode", "bypassPermissions"];
+  }
+  claudeArgs = claudeArgs.filter((a) => a !== "--print");
+
+  if (opts.maxTurns) {
+    claudeArgs.push("--max-turns", String(opts.maxTurns));
+  }
+
+  const claudeCmd = `claude ${claudeArgs.join(" ")}`;
+
+  // Transcript path: <cwd>/.session/transcript-<date>-<id>.md
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const sessionDir = `${cwd}/.session`;
+  const transcriptPath = `${sessionDir}/transcript-${dateStr}-${id}.md`;
+
+  await Bun.$`mkdir -p ${sessionDir}`.quiet();
+
+  // Create tmux session
+  await Bun.$`tmux new-session -d -s ${tmuxName} -x 200 -y 50`;
+
+  // Pipe all pane output to transcript file
+  const pipeCmd = `cat >> "${transcriptPath}"`;
+  await Bun.$`tmux pipe-pane -t ${tmuxName} -o ${pipeCmd}`;
+
+  // Launch claude in the tmux session
+  await Bun.$`tmux send-keys -t ${tmuxName} ${claudeCmd} Enter`;
+
+  // Wait for claude to initialize before sending the task
+  await Bun.sleep(2000);
+
+  // Send the task literally (no key interpretation), then Enter
+  await Bun.$`tmux send-keys -t ${tmuxName} -l ${opts.task}`;
+  await Bun.$`tmux send-keys -t ${tmuxName} Enter`;
+
+  const session: Session = {
+    id,
+    task: opts.task.slice(0, 500),
+    cwd,
+    command: claudeCmd,
+    type: "interactive",
+    tmuxName,
+    transcriptPath,
+    _lastCapturedLength: 0,
+    status: "running",
+    exitCode: null,
+    createdAt: new Date(),
+    endedAt: null,
+    output: [],
+    wsClients: new Set(),
+  };
+
+  sessions.set(id, session);
+  startTmuxPoller(session);
+
+  return toInfo(session);
+}
+
+// ---------------------------------------------------------------------------
 // Read
 // ---------------------------------------------------------------------------
 
@@ -176,13 +268,49 @@ export function listSessions(): SessionInfo[] {
   return Array.from(sessions.values()).map(toInfo);
 }
 
-export function getSession(id: string): SessionDetail | null {
+export async function getSession(id: string): Promise<SessionDetail | null> {
   const session = sessions.get(id);
   if (!session) return null;
+
+  let recentOutput = session.output.slice(-100).join("");
+
+  if (session.type === "interactive" && session.tmuxName) {
+    try {
+      const capture =
+        await Bun.$`tmux capture-pane -t ${session.tmuxName} -p -S -`.quiet();
+      recentOutput = capture.text();
+    } catch {
+      // Tmux session gone or capture failed -- use cached output
+    }
+  }
+
   return {
     ...toInfo(session),
-    recentOutput: session.output.slice(-100).join(""),
+    recentOutput,
+    transcriptPath: session.transcriptPath ?? null,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Transcript (interactive sessions only)
+// ---------------------------------------------------------------------------
+
+export async function readTranscript(
+  id: string,
+  since?: number
+): Promise<string | null> {
+  const session = sessions.get(id);
+  if (!session || !session.transcriptPath) return null;
+
+  try {
+    const file = Bun.file(session.transcriptPath);
+    if (!(await file.exists())) return "";
+    const text = await file.text();
+    if (since !== undefined && since > 0) return text.slice(since);
+    return text;
+  } catch {
+    return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -192,12 +320,19 @@ export function getSession(id: string): SessionDetail | null {
 export function killSession(id: string): boolean {
   const session = sessions.get(id);
   if (!session) return false;
+
   if (session.status === "running") {
-    session.proc.kill();
+    if (session.type === "interactive" && session.tmuxName) {
+      if (session._pollTimer) clearInterval(session._pollTimer);
+      Bun.$`tmux kill-session -t ${session.tmuxName}`.quiet().catch(() => {});
+    } else {
+      session.proc?.kill();
+    }
     session.status = "killed";
     session.endedAt = new Date();
     broadcast(session, { type: "killed" });
   }
+
   return true;
 }
 
@@ -208,11 +343,21 @@ export function killSession(id: string): boolean {
 export async function sendInput(id: string, input: string): Promise<boolean> {
   const session = sessions.get(id);
   if (!session || session.status !== "running") return false;
-  if (!session.proc.stdin) return false;
 
-  const writer = session.proc.stdin.getWriter();
-  await writer.write(new TextEncoder().encode(input));
-  writer.releaseLock();
+  if (session.type === "interactive" && session.tmuxName) {
+    try {
+      await Bun.$`tmux send-keys -t ${session.tmuxName} -l ${input}`;
+      await Bun.$`tmux send-keys -t ${session.tmuxName} Enter`;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  if (!session.proc?.stdin) return false;
+  const stdin = session.proc.stdin;
+  if (typeof stdin === "number") return false;
+  stdin.write(new TextEncoder().encode(input));
   return true;
 }
 
@@ -226,7 +371,6 @@ export function addWsClient(id: string, ws: WebSocketClient): boolean {
 
   session.wsClients.add(ws);
 
-  // Send catchup
   ws.send(
     JSON.stringify({
       type: "catchup",
@@ -256,6 +400,59 @@ export function sessionExists(id: string): boolean {
 // Internals
 // ---------------------------------------------------------------------------
 
+function startTmuxPoller(session: Session): void {
+  const timer = setInterval(async () => {
+    if (session.status !== "running" || !session.tmuxName) {
+      clearInterval(timer);
+      return;
+    }
+
+    // Check if tmux session still exists
+    try {
+      await Bun.$`tmux has-session -t ${session.tmuxName}`.quiet();
+    } catch {
+      // Tmux session ended -- claude finished or was killed externally
+      clearInterval(timer);
+      session.status = "exited";
+      session.exitCode = 0;
+      session.endedAt = new Date();
+      broadcast(session, {
+        type: "exit",
+        code: 0,
+        duration: getDuration(session),
+      });
+      setTimeout(() => {
+        for (const ws of session.wsClients) {
+          try {
+            ws.close();
+          } catch {}
+        }
+      }, 1000);
+      return;
+    }
+
+    // Capture incremental output for WS broadcast
+    try {
+      const capture =
+        await Bun.$`tmux capture-pane -t ${session.tmuxName} -p -S -`.quiet();
+      const fullText = capture.text();
+      const newText = fullText.slice(session._lastCapturedLength);
+      if (newText) {
+        session._lastCapturedLength = fullText.length;
+        session.output.push(newText);
+        while (session.output.length > config.outputBufferSize) {
+          session.output.shift();
+        }
+        broadcast(session, { type: "stdout", data: newText });
+      }
+    } catch {
+      // Capture failed -- skip this tick
+    }
+  }, 2000);
+
+  session._pollTimer = timer;
+}
+
 function streamReader(
   session: Session,
   stream: ReadableStream<Uint8Array> | null,
@@ -274,7 +471,6 @@ function streamReader(
         const text = decoder.decode(value);
         session.output.push(text);
 
-        // Trim buffer
         while (session.output.length > config.outputBufferSize) {
           session.output.shift();
         }
@@ -309,9 +505,10 @@ function toInfo(session: Session): SessionInfo {
     task: session.task,
     cwd: session.cwd,
     command: session.command,
+    type: session.type,
     status: session.status,
     exitCode: session.exitCode,
-    pid: session.proc.pid,
+    pid: session.proc?.pid ?? null,
     createdAt: session.createdAt.toISOString(),
     endedAt: session.endedAt?.toISOString() || null,
     outputLines: session.output.length,


### PR DESCRIPTION
Adds persistent interactive Claude sessions via tmux. Closes #2.

**New mode:** `POST /sessions` with `mode: "interactive"`

**How it works:**
- Spawns `claude` (no --print) inside a tmux session (`mp-<id>`)
- `pipe-pane` streams output to `.session/transcript-<date>-<id>.md`
- Input via `tmux send-keys` (POST /sessions/:id/input)
- Exit detection via 2s tmux poller
- Incremental transcript reads via `GET /sessions/:id/transcript?since=<offset>`

**Benefits over --print mode:**
- Persistent sessions = cache builds up (80%+ hit rate vs 59%)
- Interactive = agent can ask questions, user can steer
- Transcript file = VS Code split view for real-time monitoring
- No dead PTY issues (tmux handles the terminal)

**New presets:** `claude-interactive`, `claude-interactive-sonnet`, `claude-interactive-opus`