### PR TITLE
fix: Update preset model names to match LiteLLM aliases (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ curl -X POST http://localhost:3200/sessions \
   -d '{"task": "Fix the bug", "cwd": "/path/to/repo", "preset": "claude"}'
 ```
 
-Built-in presets: `claude`, `claude-sonnet`, `codex`, `codex-auto`
+Built-in presets: `claude`, `claude-sonnet`, `claude-opus`, `claude-haiku`, `codex`, `codex-auto`, `codex-gpt55`
 
 ## License
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,12 @@ export const config = {
 /**
  * Agent presets -- common command + args combos.
  * Model names must match LiteLLM proxy aliases (10.71.1.33:4000).
+ *
+ * LiteLLM aliases:
+ *   opus-nocache    -> Claude Opus
+ *   sonnet-nocache  -> Claude Sonnet
+ *   haiku-nocache   -> Claude Haiku
+ *   openai/gpt-5.5  -> OpenAI GPT-5.5 (direct/Codex sub)
  */
 export const presets: Record<string, { command: string; args: string[] }> = {
   claude: {
@@ -22,11 +28,15 @@ export const presets: Record<string, { command: string; args: string[] }> = {
   },
   "claude-sonnet": {
     command: "claude",
-    args: ["--print", "--permission-mode", "bypassPermissions", "--model", "sonnet"],
+    args: ["--print", "--permission-mode", "bypassPermissions", "--model", "sonnet-nocache"],
   },
   "claude-opus": {
     command: "claude",
-    args: ["--print", "--permission-mode", "bypassPermissions", "--model", "opus"],
+    args: ["--print", "--permission-mode", "bypassPermissions", "--model", "opus-nocache"],
+  },
+  "claude-haiku": {
+    command: "claude",
+    args: ["--print", "--permission-mode", "bypassPermissions", "--model", "haiku-nocache"],
   },
   codex: {
     command: "codex",
@@ -36,16 +46,24 @@ export const presets: Record<string, { command: string; args: string[] }> = {
     command: "codex",
     args: ["exec", "--full-auto"],
   },
+  "codex-gpt55": {
+    command: "codex",
+    args: ["exec", "--model", "openai/gpt-5.5"],
+  },
   "claude-interactive": {
     command: "claude",
     args: ["--permission-mode", "bypassPermissions"],
   },
   "claude-interactive-sonnet": {
     command: "claude",
-    args: ["--permission-mode", "bypassPermissions", "--model", "sonnet"],
+    args: ["--permission-mode", "bypassPermissions", "--model", "sonnet-nocache"],
   },
   "claude-interactive-opus": {
     command: "claude",
-    args: ["--permission-mode", "bypassPermissions", "--model", "opus"],
+    args: ["--permission-mode", "bypassPermissions", "--model", "opus-nocache"],
+  },
+  "claude-interactive-haiku": {
+    command: "claude",
+    args: ["--permission-mode", "bypassPermissions", "--model", "haiku-nocache"],
   },
 };


### PR DESCRIPTION
Updates all preset model names to match LiteLLM aliases:
- `sonnet` → `sonnet-nocache`
- `opus` → `opus-nocache`
- Added `haiku-nocache` presets
- Added `openai/gpt-5.5` (Codex) preset
- Updated README preset list

Builds clean. Closes #4