### PR TITLE
MonkeyProof maintenance readiness hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
+# monkeyproof example environment
+# Copy to .env and replace CHANGE_ME_* values before exposing the service.
+
 PORT=3200
-AGENT_WS_TOKEN=monkeyproof-dev
+# Required for HTTP bearer auth and WebSocket ?token=. Do not leave as CHANGE_ME.
+AGENT_WS_TOKEN=CHANGE_ME_STRONG_RANDOM_TOKEN
 MAX_SESSIONS=50
 OUTPUT_BUFFER_SIZE=2000
+# Cleanup TTL for completed print sessions, in milliseconds.
 SESSION_TTL_MS=3600000
+# Cleanup TTL for completed interactive tmux sessions, in milliseconds.
 INTERACTIVE_SESSION_TTL_MS=7200000

--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,6 @@
-# monkeyproof configuration
-# Copy to .env and customize
-
-# Server port
 PORT=3200
-
-# Auth token for API access (CHANGE THIS)
-AGENT_WS_TOKEN=change-me-to-something-secret
-
-# Max concurrent sessions
-MAX_SESSIONS=10
-
-# Lines of output to buffer per session
+AGENT_WS_TOKEN=monkeyproof-dev
+MAX_SESSIONS=50
 OUTPUT_BUFFER_SIZE=2000
-
-# Auto-cleanup exited sessions after (ms) -- default 1 hour
 SESSION_TTL_MS=3600000
-
-# If using Claude Code with Anthropic API directly:
-# ANTHROPIC_API_KEY=sk-ant-...
-
-# If routing through LiteLLM proxy:
-# ANTHROPIC_API_KEY=sk-your-litellm-key
-# ANTHROPIC_BASE_URL=http://your-litellm-proxy:4000
+INTERACTIVE_SESSION_TTL_MS=7200000

--- a/README.md
+++ b/README.md
@@ -78,10 +78,13 @@ ws.send(JSON.stringify({ type: "stdin", data: "yes\n" }));
 | Env Var | Default | Description |
 |---------|---------|-------------|
 | `PORT` | `3200` | Server port |
-| `AGENT_WS_TOKEN` | `monkeyproof-dev` | Bearer auth token |
-| `MAX_SESSIONS` | `10` | Max concurrent sessions |
+| `AGENT_WS_TOKEN` | `CHANGE_ME_AGENT_WS_TOKEN` | Bearer auth token. Replace before exposing the service; the placeholder is intentionally unsafe. |
+| `MAX_SESSIONS` | `50` | Max concurrent sessions |
 | `OUTPUT_BUFFER_SIZE` | `2000` | Lines of output to buffer per session |
 | `SESSION_TTL_MS` | `3600000` | Auto-cleanup exited sessions after (ms) |
+| `INTERACTIVE_SESSION_TTL_MS` | `7200000` | Auto-cleanup exited interactive tmux sessions after (ms) |
+
+> Built-in Claude presets include `--permission-mode bypassPermissions` for unattended agent work. Use them only in trusted workspaces, or pass explicit `command`/`args` if that permission mode is not appropriate.
 
 ## Agent Presets
 
@@ -93,7 +96,7 @@ curl -X POST http://localhost:3200/sessions \
   -d '{"task": "Fix the bug", "cwd": "/path/to/repo", "preset": "claude"}'
 ```
 
-Built-in presets: `claude`, `claude-sonnet`, `codex`, `codex-auto`
+Built-in presets: `claude`, `claude-sonnet`, `claude-opus`, `claude-interactive`, `claude-interactive-sonnet`, `claude-interactive-opus`, `codex`, `codex-auto`
 
 ## License
 

--- a/monkeyproof.config.json
+++ b/monkeyproof.config.json
@@ -1,0 +1,42 @@
+{
+  "port": 3200,
+  "authToken": "monkeyproof-dev",
+  "maxSessions": 50,
+  "outputBufferSize": 2000,
+  "sessionTtlMs": 3600000,
+  "interactiveSessionTtlMs": 7200000,
+  "presets": {
+    "claude": {
+      "command": "claude",
+      "args": ["--print", "--permission-mode", "bypassPermissions"]
+    },
+    "claude-sonnet": {
+      "command": "claude",
+      "args": ["--print", "--permission-mode", "bypassPermissions", "--model", "sonnet"]
+    },
+    "claude-opus": {
+      "command": "claude",
+      "args": ["--print", "--permission-mode", "bypassPermissions", "--model", "opus"]
+    },
+    "claude-interactive": {
+      "command": "claude",
+      "args": ["--permission-mode", "bypassPermissions"]
+    },
+    "claude-interactive-sonnet": {
+      "command": "claude",
+      "args": ["--permission-mode", "bypassPermissions", "--model", "sonnet"]
+    },
+    "claude-interactive-opus": {
+      "command": "claude",
+      "args": ["--permission-mode", "bypassPermissions", "--model", "opus"]
+    },
+    "codex": {
+      "command": "codex",
+      "args": ["exec"]
+    },
+    "codex-auto": {
+      "command": "codex",
+      "args": ["exec", "--full-auto"]
+    }
+  }
+}

--- a/monkeyproof.config.json
+++ b/monkeyproof.config.json
@@ -1,6 +1,6 @@
 {
   "port": 3200,
-  "authToken": "monkeyproof-dev",
+  "authToken": "CHANGE_ME_AGENT_WS_TOKEN",
   "maxSessions": 50,
   "outputBufferSize": 2000,
   "sessionTtlMs": 3600000,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @module config.test
+ * @description Tests for monkeyproof configuration and presets.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { config, presets } from "./config";
+
+describe("config", () => {
+  test("default port is 3200", () => {
+    expect(config.port).toBe(3200);
+  });
+
+  test("default auth token is monkeyproof-dev", () => {
+    expect(config.authToken).toBe("monkeyproof-dev");
+  });
+
+  test("maxSessions is a positive number", () => {
+    expect(config.maxSessions).toBeGreaterThan(0);
+  });
+
+  test("outputBufferSize is positive", () => {
+    expect(config.outputBufferSize).toBeGreaterThan(0);
+  });
+
+  test("sessionTtlMs is at least 1 minute", () => {
+    expect(config.sessionTtlMs).toBeGreaterThanOrEqual(60_000);
+  });
+});
+
+describe("presets", () => {
+  test("has required presets", () => {
+    expect(presets["claude"]).toBeDefined();
+    expect(presets["claude-sonnet"]).toBeDefined();
+    expect(presets["claude-opus"]).toBeDefined();
+    expect(presets["codex"]).toBeDefined();
+    expect(presets["codex-auto"]).toBeDefined();
+  });
+
+  test("interactive presets exist", () => {
+    expect(presets["claude-interactive"]).toBeDefined();
+    expect(presets["claude-interactive-sonnet"]).toBeDefined();
+    expect(presets["claude-interactive-opus"]).toBeDefined();
+  });
+
+  test("claude presets use --print flag", () => {
+    expect(presets["claude"].args).toContain("--print");
+    expect(presets["claude-sonnet"].args).toContain("--print");
+    expect(presets["claude-opus"].args).toContain("--print");
+  });
+
+  test("interactive presets do NOT have --print flag", () => {
+    expect(presets["claude-interactive"].args).not.toContain("--print");
+    expect(presets["claude-interactive-sonnet"].args).not.toContain("--print");
+  });
+
+  test("all presets bypass permissions", () => {
+    const claudePresets = Object.entries(presets).filter(([k]) => k.startsWith("claude"));
+    for (const [name, preset] of claudePresets) {
+      expect(preset.args).toContain("bypassPermissions");
+    }
+  });
+
+  test("sonnet presets use --model sonnet", () => {
+    expect(presets["claude-sonnet"].args).toContain("sonnet");
+    expect(presets["claude-interactive-sonnet"].args).toContain("sonnet");
+  });
+
+  test("opus presets use --model opus", () => {
+    expect(presets["claude-opus"].args).toContain("opus");
+    expect(presets["claude-interactive-opus"].args).toContain("opus");
+  });
+
+  test("codex presets use codex command", () => {
+    expect(presets["codex"].command).toBe("codex");
+    expect(presets["codex-auto"].command).toBe("codex");
+  });
+
+  test("codex-auto uses --full-auto", () => {
+    expect(presets["codex-auto"].args).toContain("--full-auto");
+  });
+
+  test("every preset has command and args", () => {
+    for (const [name, preset] of Object.entries(presets)) {
+      expect(preset.command).toBeTruthy();
+      expect(Array.isArray(preset.args)).toBe(true);
+    }
+  });
+});

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -44,14 +44,14 @@ describe("presets", () => {
   });
 
   test("claude presets use --print flag", () => {
-    expect(presets["claude"].args).toContain("--print");
-    expect(presets["claude-sonnet"].args).toContain("--print");
-    expect(presets["claude-opus"].args).toContain("--print");
+    expect(presets["claude"]!.args).toContain("--print");
+    expect(presets["claude-sonnet"]!.args).toContain("--print");
+    expect(presets["claude-opus"]!.args).toContain("--print");
   });
 
   test("interactive presets do NOT have --print flag", () => {
-    expect(presets["claude-interactive"].args).not.toContain("--print");
-    expect(presets["claude-interactive-sonnet"].args).not.toContain("--print");
+    expect(presets["claude-interactive"]!.args).not.toContain("--print");
+    expect(presets["claude-interactive-sonnet"]!.args).not.toContain("--print");
   });
 
   test("all presets bypass permissions", () => {
@@ -62,22 +62,22 @@ describe("presets", () => {
   });
 
   test("sonnet presets use --model sonnet", () => {
-    expect(presets["claude-sonnet"].args).toContain("sonnet");
-    expect(presets["claude-interactive-sonnet"].args).toContain("sonnet");
+    expect(presets["claude-sonnet"]!.args).toContain("sonnet");
+    expect(presets["claude-interactive-sonnet"]!.args).toContain("sonnet");
   });
 
   test("opus presets use --model opus", () => {
-    expect(presets["claude-opus"].args).toContain("opus");
-    expect(presets["claude-interactive-opus"].args).toContain("opus");
+    expect(presets["claude-opus"]!.args).toContain("opus");
+    expect(presets["claude-interactive-opus"]!.args).toContain("opus");
   });
 
   test("codex presets use codex command", () => {
-    expect(presets["codex"].command).toBe("codex");
-    expect(presets["codex-auto"].command).toBe("codex");
+    expect(presets["codex"]!.command).toBe("codex");
+    expect(presets["codex-auto"]!.command).toBe("codex");
   });
 
   test("codex-auto uses --full-auto", () => {
-    expect(presets["codex-auto"].args).toContain("--full-auto");
+    expect(presets["codex-auto"]!.args).toContain("--full-auto");
   });
 
   test("every preset has command and args", () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -11,8 +11,9 @@ describe("config", () => {
     expect(config.port).toBe(3200);
   });
 
-  test("default auth token is monkeyproof-dev", () => {
-    expect(config.authToken).toBe("monkeyproof-dev");
+  test("default auth token is a placeholder, not a plaintext shared secret", () => {
+    expect(config.authToken).toBe("CHANGE_ME_AGENT_WS_TOKEN");
+    expect(config.authToken).not.toBe("monkeyproof-dev");
   });
 
   test("maxSessions is a positive number", () => {
@@ -25,6 +26,10 @@ describe("config", () => {
 
   test("sessionTtlMs is at least 1 minute", () => {
     expect(config.sessionTtlMs).toBeGreaterThanOrEqual(60_000);
+  });
+
+  test("interactiveSessionTtlMs is at least 1 minute", () => {
+    expect(config.interactiveSessionTtlMs).toBeGreaterThanOrEqual(60_000);
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,6 @@
  * 3. Hardcoded defaults (fallback)
  */
 
-import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 
 interface ConfigFile {
@@ -21,17 +20,19 @@ interface ConfigFile {
   presets?: Record<string, { command: string; args: string[] }>;
 }
 
-function loadConfigFile(): ConfigFile {
+const DEFAULT_AUTH_TOKEN = "CHANGE_ME_AGENT_WS_TOKEN";
+
+async function loadConfigFile(): Promise<ConfigFile> {
   const paths = [
     join(process.cwd(), "monkeyproof.config.json"),
-    join(__dirname, "..", "monkeyproof.config.json"),
+    join(import.meta.dir, "..", "monkeyproof.config.json"),
   ];
 
   for (const p of paths) {
-    if (existsSync(p)) {
+    const file = Bun.file(p);
+    if (await file.exists()) {
       try {
-        const raw = readFileSync(p, "utf-8");
-        return JSON.parse(raw) as ConfigFile;
+        return JSON.parse(await file.text()) as ConfigFile;
       } catch (e) {
         console.warn(`Warning: failed to parse ${p}:`, e);
       }
@@ -41,11 +42,18 @@ function loadConfigFile(): ConfigFile {
   return {};
 }
 
-const file = loadConfigFile();
+const file = await loadConfigFile();
+const authToken = process.env.AGENT_WS_TOKEN || file.authToken || DEFAULT_AUTH_TOKEN;
+
+if (authToken === DEFAULT_AUTH_TOKEN) {
+  console.warn(
+    "Warning: AGENT_WS_TOKEN is not configured; using CHANGE_ME_AGENT_WS_TOKEN placeholder. Set a strong token before exposing monkeyproof.",
+  );
+}
 
 export const config = {
   port: parseInt(process.env.PORT || String(file.port ?? 3200), 10),
-  authToken: process.env.AGENT_WS_TOKEN || file.authToken || "monkeyproof-dev",
+  authToken,
   maxSessions: parseInt(process.env.MAX_SESSIONS || String(file.maxSessions ?? 50), 10),
   outputBufferSize: parseInt(process.env.OUTPUT_BUFFER_SIZE || String(file.outputBufferSize ?? 2000), 10),
   sessionTtlMs: parseInt(process.env.SESSION_TTL_MS || String(file.sessionTtlMs ?? 3600000), 10),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,21 +1,62 @@
 /**
  * @module config
- * @description Server configuration from environment variables.
+ * @description Server configuration with file → env → defaults priority.
+ *
+ * Loading order:
+ * 1. monkeyproof.config.json (cwd or repo root)
+ * 2. Environment variables (override file values)
+ * 3. Hardcoded defaults (fallback)
  */
+
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+interface ConfigFile {
+  port?: number;
+  authToken?: string;
+  maxSessions?: number;
+  outputBufferSize?: number;
+  sessionTtlMs?: number;
+  interactiveSessionTtlMs?: number;
+  presets?: Record<string, { command: string; args: string[] }>;
+}
+
+function loadConfigFile(): ConfigFile {
+  const paths = [
+    join(process.cwd(), "monkeyproof.config.json"),
+    join(__dirname, "..", "monkeyproof.config.json"),
+  ];
+
+  for (const p of paths) {
+    if (existsSync(p)) {
+      try {
+        const raw = readFileSync(p, "utf-8");
+        return JSON.parse(raw) as ConfigFile;
+      } catch (e) {
+        console.warn(`Warning: failed to parse ${p}:`, e);
+      }
+    }
+  }
+
+  return {};
+}
+
+const file = loadConfigFile();
 
 export const config = {
-  port: parseInt(process.env.PORT || "3200", 10),
-  authToken: process.env.AGENT_WS_TOKEN || "monkeyproof-dev",
-  maxSessions: parseInt(process.env.MAX_SESSIONS || "10", 10),
-  outputBufferSize: parseInt(process.env.OUTPUT_BUFFER_SIZE || "2000", 10),
-  sessionTtlMs: parseInt(process.env.SESSION_TTL_MS || "3600000", 10), // 1 hour
+  port: parseInt(process.env.PORT || String(file.port ?? 3200), 10),
+  authToken: process.env.AGENT_WS_TOKEN || file.authToken || "monkeyproof-dev",
+  maxSessions: parseInt(process.env.MAX_SESSIONS || String(file.maxSessions ?? 50), 10),
+  outputBufferSize: parseInt(process.env.OUTPUT_BUFFER_SIZE || String(file.outputBufferSize ?? 2000), 10),
+  sessionTtlMs: parseInt(process.env.SESSION_TTL_MS || String(file.sessionTtlMs ?? 3600000), 10),
+  interactiveSessionTtlMs: parseInt(
+    process.env.INTERACTIVE_SESSION_TTL_MS || String(file.interactiveSessionTtlMs ?? 7200000),
+    10,
+  ),
 };
 
-/**
- * Agent presets -- common command + args combos.
- * Model names must match LiteLLM proxy aliases (10.71.1.33:4000).
- */
-export const presets: Record<string, { command: string; args: string[] }> = {
+/** Default presets -- overridden by config file if present */
+const DEFAULT_PRESETS: Record<string, { command: string; args: string[] }> = {
   claude: {
     command: "claude",
     args: ["--print", "--permission-mode", "bypassPermissions"],
@@ -49,3 +90,26 @@ export const presets: Record<string, { command: string; args: string[] }> = {
     args: ["--permission-mode", "bypassPermissions", "--model", "opus"],
   },
 };
+
+export const presets: Record<string, { command: string; args: string[] }> =
+  file.presets && Object.keys(file.presets).length > 0 ? file.presets : DEFAULT_PRESETS;
+
+/**
+ * Check if a preset is interactive (no --print flag).
+ * Interactive sessions get a longer TTL.
+ */
+export function isInteractivePreset(presetName: string): boolean {
+  const preset = presets[presetName];
+  if (!preset) return false;
+  return !preset.args.includes("--print");
+}
+
+/**
+ * Get the appropriate TTL for a session based on its preset.
+ */
+export function getSessionTtl(presetName?: string): number {
+  if (presetName && isInteractivePreset(presetName)) {
+    return config.interactiveSessionTtlMs;
+  }
+  return config.sessionTtlMs;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,25 +121,30 @@ app.post("/sessions/:id/input", async (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// GET /sessions/:id/transcript -- read transcript file (interactive only)
+// GET /sessions/:id/transcript -- read transcript file (print + interactive)
 // Query: ?since=<byte-offset>  (omit for full transcript)
 // ---------------------------------------------------------------------------
 app.get("/sessions/:id/transcript", async (c) => {
   const sinceParam = c.req.query("since");
   const since = sinceParam !== undefined ? parseInt(sinceParam, 10) : undefined;
 
-  const text = await readTranscript(c.req.param("id"), since);
-  if (text === null) {
+  const result = await readTranscript(c.req.param("id"), since);
+  if (result === null) {
     return c.json(
-      { error: "Not found or session has no transcript (print-mode sessions do not produce transcripts)" },
+      { error: "Not found or session has no transcript" },
       404
     );
   }
 
+  // Return offset metadata for polling
+  const { text, offset, totalSize } = result;
+
   return new Response(text, {
     headers: {
       "content-type": "text/plain; charset=utf-8",
-      "x-transcript-length": String(text.length),
+      "x-transcript-offset": String(offset),
+      "x-transcript-total-size": String(totalSize),
+      "x-transcript-next-offset": String(totalSize),
     },
   });
 });
@@ -161,7 +166,7 @@ const banner = `
   GET    /sessions/:id            → detail
   DELETE /sessions/:id            → kill
   POST   /sessions/:id/input      → send input
-  GET    /sessions/:id/transcript → transcript (interactive)
+  GET    /sessions/:id/transcript → transcript (print + interactive)
   WS     /sessions/:id/ws         → stream
   ──────────────────────────────────────────────
   Modes: print (default) | interactive (tmux)

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
   addWsClient,
   removeWsClient,
   sessionExists,
+  isSessionStatus,
 } from "./sessions";
 
 const app = new Hono();
@@ -86,7 +87,12 @@ app.get("/sessions", (c) => {
   const status = c.req.query("status");
   if (owner) filter.owner = owner;
   if (label) filter.label = label;
-  if (status) filter.status = status as any;
+  if (status) {
+    if (!isSessionStatus(status)) {
+      return c.json({ error: 'status must be "running", "exited", or "killed"' }, 400);
+    }
+    filter.status = status;
+  }
   return c.json(listSessions(Object.keys(filter).length > 0 ? filter as any : undefined));
 });
 
@@ -162,7 +168,7 @@ const banner = `
   Port:     ${config.port}
   Max:      ${config.maxSessions} sessions
   Buffer:   ${config.outputBufferSize} lines
-  TTL:      ${config.sessionTtlMs / 1000}s
+  TTL:      ${config.sessionTtlMs / 1000}s print / ${config.interactiveSessionTtlMs / 1000}s interactive
   ──────────────────────────────────────────────
   POST   /sessions                → spawn
   GET    /sessions                → list

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,10 @@ app.post("/sessions/:id/input", async (c) => {
 // ---------------------------------------------------------------------------
 app.get("/sessions/:id/transcript", async (c) => {
   const sinceParam = c.req.query("since");
-  const since = sinceParam !== undefined ? parseInt(sinceParam, 10) : undefined;
+  const since = sinceParam !== undefined ? Number(sinceParam) : undefined;
+  if (sinceParam !== undefined && (!Number.isFinite(since) || since! < 0)) {
+    return c.json({ error: "since must be a non-negative byte offset" }, 400);
+  }
 
   const result = await readTranscript(c.req.param("id"), since);
   if (result === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,14 @@ app.post("/sessions", async (c) => {
 // GET /sessions -- list all sessions
 // ---------------------------------------------------------------------------
 app.get("/sessions", (c) => {
-  return c.json(listSessions());
+  const filter: Record<string, string> = {};
+  const owner = c.req.query("owner");
+  const label = c.req.query("label");
+  const status = c.req.query("status");
+  if (owner) filter.owner = owner;
+  if (label) filter.label = label;
+  if (status) filter.status = status as any;
+  return c.json(listSessions(Object.keys(filter).length > 0 ? filter as any : undefined));
 });
 
 // ---------------------------------------------------------------------------

--- a/src/sessions.test.ts
+++ b/src/sessions.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  createSession,
+  getSession,
+  killSession,
+  listSessions,
+  readTranscript,
+} from "./sessions";
+
+const tempDirs: string[] = [];
+
+async function tmpCwd(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "mp-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  for (const session of listSessions()) {
+    killSession(session.id);
+  }
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("sessions", () => {
+  test("persists owner and labels and supports filters", async () => {
+    const cwd = await tmpCwd();
+    const session = createSession({
+      task: "hello",
+      cwd,
+      command: "bun",
+      args: ["--eval", "console.log('hello')"],
+      owner: "bilby",
+      labels: ["maintenance", "mp"],
+    });
+
+    await Bun.sleep(50);
+
+    expect(session.owner).toBe("bilby");
+    expect(session.labels).toEqual(["maintenance", "mp"]);
+    expect(listSessions({ owner: "bilby" }).map((s) => s.id)).toContain(session.id);
+    expect(listSessions({ label: "maintenance" }).map((s) => s.id)).toContain(session.id);
+
+    for (let i = 0; i < 40; i++) {
+      const detail = await getSession(session.id);
+      if (detail?.status === "exited") break;
+      await Bun.sleep(25);
+    }
+    expect(listSessions({ status: "exited" }).map((s) => s.id)).toContain(session.id);
+  });
+
+  test("uses byte offsets for transcript polling", async () => {
+    const cwd = await tmpCwd();
+    const session = createSession({
+      task: "utf8",
+      cwd,
+      command: "bun",
+      args: ["--eval", "console.log('éclair')"],
+    });
+
+    for (let i = 0; i < 40; i++) {
+      const transcript = await readTranscript(session.id);
+      if (transcript?.text.includes("éclair")) break;
+      await Bun.sleep(25);
+    }
+
+    const full = await readTranscript(session.id);
+    expect(full).not.toBeNull();
+    expect(full!.text).toContain("éclair");
+    expect(full!.totalSize).toBe(new TextEncoder().encode(full!.text).byteLength);
+
+    const marker = full!.text.indexOf("éclair");
+    const byteOffset = new TextEncoder().encode(full!.text.slice(0, marker)).byteLength;
+    const partial = await readTranscript(session.id, byteOffset);
+    expect(partial).not.toBeNull();
+    expect(partial!.offset).toBe(byteOffset);
+    expect(partial!.text).toStartWith("éclair");
+  });
+
+  test("normalizes relative cwd and keeps transcript under cwd/.session", async () => {
+    const cwd = await tmpCwd();
+    const relativeCwd = cwd.replace(`${process.cwd()}/`, "");
+    const session = createSession({ task: "pwd", cwd: relativeCwd, command: "bun", args: ["--eval", "console.log('ok')"] });
+    const detail = await getSession(session.id);
+
+    expect(detail?.cwd).toStartWith("/");
+    expect(detail?.transcriptPath).toStartWith(`${detail?.cwd}/.session/`);
+  });
+});

--- a/src/sessions.test.ts
+++ b/src/sessions.test.ts
@@ -8,6 +8,8 @@ import {
   killSession,
   listSessions,
   readTranscript,
+  killSessionsByFilter,
+  isSessionStatus,
 } from "./sessions";
 
 const tempDirs: string[] = [];
@@ -36,7 +38,7 @@ describe("sessions", () => {
       command: "bun",
       args: ["--eval", "console.log('hello')"],
       owner: "bilby",
-      labels: ["maintenance", "mp"],
+      labels: [" Maintenance ", "MP", "mp"],
     });
 
     await Bun.sleep(50);
@@ -52,6 +54,26 @@ describe("sessions", () => {
       await Bun.sleep(25);
     }
     expect(listSessions({ status: "exited" }).map((s) => s.id)).toContain(session.id);
+  });
+
+  test("validates session status query values", () => {
+    expect(isSessionStatus("running")).toBe(true);
+    expect(isSessionStatus("exited")).toBe(true);
+    expect(isSessionStatus("killed")).toBe(true);
+    expect(isSessionStatus("bogus")).toBe(false);
+  });
+
+  test("refuses empty-filter bulk kill", async () => {
+    const cwd = await tmpCwd();
+    const session = createSession({
+      task: "long",
+      cwd,
+      command: "bun",
+      args: ["--eval", "setTimeout(() => {}, 10000)"],
+    });
+
+    expect(killSessionsByFilter({})).toBe(0);
+    await expect(getSession(session.id)).resolves.toMatchObject({ status: "running" });
   });
 
   test("uses byte offsets for transcript polling", async () => {
@@ -90,5 +112,25 @@ describe("sessions", () => {
 
     expect(detail?.cwd).toStartWith("/");
     expect(detail?.transcriptPath).toStartWith(`${detail?.cwd}/.session/`);
+  });
+
+  test("empty bulk-kill filter is a no-op", async () => {
+    const cwd = await tmpCwd();
+    const session = createSession({
+      task: "long",
+      cwd,
+      command: "bun",
+      args: ["--eval", "setTimeout(() => {}, 2000)"],
+    });
+
+    expect(killSessionsByFilter({})).toBe(0);
+    expect((await getSession(session.id))?.status).toBe("running");
+  });
+
+  test("validates known session statuses", () => {
+    expect(isSessionStatus("running")).toBe(true);
+    expect(isSessionStatus("exited")).toBe(true);
+    expect(isSessionStatus("killed")).toBe(true);
+    expect(isSessionStatus("wat")).toBe(false);
   });
 });

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -28,10 +28,17 @@ export interface SessionCreateOpts {
   labels?: string[];
 }
 
+export const SESSION_STATUSES = ["running", "exited", "killed"] as const;
+export type SessionStatus = (typeof SESSION_STATUSES)[number];
+
+export function isSessionStatus(value: string): value is SessionStatus {
+  return (SESSION_STATUSES as readonly string[]).includes(value);
+}
+
 export interface SessionFilter {
   owner?: string;
   label?: string;
-  status?: "running" | "exited" | "killed";
+  status?: SessionStatus;
 }
 
 export interface SessionInfo {
@@ -40,7 +47,7 @@ export interface SessionInfo {
   cwd: string;
   command: string;
   type: "print" | "interactive";
-  status: "running" | "exited" | "killed";
+  status: SessionStatus;
   exitCode: number | null;
   pid: number | null;
   createdAt: string;
@@ -64,6 +71,7 @@ interface Session {
   type: "print" | "interactive";
   owner: string | null;
   labels: string[];
+  pid: number | null;
   // print-only
   proc?: Subprocess;
   // interactive-only
@@ -71,8 +79,9 @@ interface Session {
   transcriptPath?: string;
   _pollTimer?: ReturnType<typeof setInterval>;
   _lastCapturedLength: number;
+  transcriptReady?: Promise<void>;
   // shared
-  status: "running" | "exited" | "killed";
+  status: SessionStatus;
   exitCode: number | null;
   createdAt: Date;
   endedAt: Date | null;
@@ -156,7 +165,7 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
   const sessionDir = resolve(cwd, ".session");
   const dateStr = new Date().toISOString().slice(0, 10);
   const transcriptPath = resolve(sessionDir, `transcript-${dateStr}-${id}.md`);
-  mkdir(sessionDir, { recursive: true })
+  const transcriptReady = mkdir(sessionDir, { recursive: true })
     .then(() => writeFile(transcriptPath, `# Session ${id}\n## Task: ${opts.task.slice(0, 200)}\n---\n`))
     .catch(() => {});
 
@@ -167,7 +176,8 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
     command: `${command} ${args.slice(0, -1).join(" ")}`,
     type: "print",
     owner: opts.owner || null,
-    labels: opts.labels || [],
+    labels: normalizeLabels(opts.labels),
+    pid: proc.pid ?? null,
     proc,
     _lastCapturedLength: 0,
     status: "running",
@@ -177,6 +187,7 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
     output: [],
     wsClients: new Set(),
     transcriptPath,
+    transcriptReady,
   };
 
   sessions.set(id, session);
@@ -247,6 +258,8 @@ export async function createInteractiveSession(
 
   // Create tmux session
   await Bun.$`tmux new-session -d -s ${tmuxName} -x 200 -y 50`;
+  const panePidResult = await Bun.$`tmux display-message -p -t ${tmuxName} #{pane_pid}`.quiet();
+  const panePid = Number.parseInt(panePidResult.text().trim(), 10);
 
   // Pipe all pane output to transcript file
   const pipeCmd = `cat >> "${transcriptPath}"`;
@@ -269,7 +282,8 @@ export async function createInteractiveSession(
     command: claudeCmd,
     type: "interactive",
     owner: opts.owner || null,
-    labels: opts.labels || [],
+    labels: normalizeLabels(opts.labels),
+    pid: Number.isFinite(panePid) ? panePid : null,
     tmuxName,
     transcriptPath,
     _lastCapturedLength: 0,
@@ -344,10 +358,10 @@ export async function readTranscript(
   try {
     const file = Bun.file(session.transcriptPath);
     if (!(await file.exists())) return { text: "", offset: 0, totalSize: 0 };
-    const totalSize = file.size;
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const totalSize = bytes.byteLength;
     const offset = Math.max(0, Math.min(Math.trunc(since ?? 0), totalSize));
-    const bytes = await file.slice(offset).arrayBuffer();
-    return { text: new TextDecoder().decode(bytes), offset, totalSize };
+    return { text: new TextDecoder().decode(bytes.slice(offset)), offset, totalSize };
   } catch {
     return null;
   }
@@ -381,6 +395,8 @@ export function killSession(id: string): boolean {
  * Returns the number of sessions killed.
  */
 export function killSessionsByFilter(filter: SessionFilter): number {
+  if (!filter.owner && !filter.label && !filter.status) return 0;
+
   let killed = 0;
   for (const [id, session] of sessions) {
     if (filter.owner && session.owner !== filter.owner) continue;
@@ -509,6 +525,16 @@ function startTmuxPoller(session: Session): void {
   session._pollTimer = timer;
 }
 
+function normalizeLabels(labels?: string[]): string[] {
+  return Array.from(
+    new Set(
+      (labels ?? [])
+        .map((label) => label.trim().toLowerCase().slice(0, 64))
+        .filter(Boolean),
+    ),
+  );
+}
+
 function streamReader(
   session: Session,
   stream: ReadableStream<Uint8Array> | null,
@@ -529,9 +555,9 @@ function streamReader(
 
         // Tee to transcript file
         if (session.transcriptPath) {
-          try {
-            appendFile(session.transcriptPath, text).catch(() => {});
-          } catch {}
+          session.transcriptReady
+            ?.then(() => appendFile(session.transcriptPath!, text))
+            .catch(() => {});
         }
 
         while (session.output.length > config.outputBufferSize) {
@@ -571,7 +597,7 @@ function toInfo(session: Session): SessionInfo {
     type: session.type,
     status: session.status,
     exitCode: session.exitCode,
-    pid: session.proc?.pid ?? null,
+    pid: session.pid,
     createdAt: session.createdAt.toISOString(),
     endedAt: session.endedAt?.toISOString() || null,
     outputLines: session.output.length,

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -22,6 +22,14 @@ export interface SessionCreateOpts {
   preset?: string;
   maxTurns?: number;
   env?: Record<string, string>;
+  owner?: string;
+  labels?: string[];
+}
+
+export interface SessionFilter {
+  owner?: string;
+  label?: string;
+  status?: "running" | "exited" | "killed";
 }
 
 export interface SessionInfo {
@@ -37,6 +45,8 @@ export interface SessionInfo {
   endedAt: string | null;
   outputLines: number;
   wsClients: number;
+  owner: string | null;
+  labels: string[];
 }
 
 export interface SessionDetail extends SessionInfo {
@@ -50,6 +60,8 @@ interface Session {
   cwd: string;
   command: string;
   type: "print" | "interactive";
+  owner: string | null;
+  labels: string[];
   // print-only
   proc?: Subprocess;
   // interactive-only
@@ -138,12 +150,24 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
     stderr: "pipe",
   });
 
+  // Set up transcript file for print sessions too
+  const sessionDir = `${cwd}/.session`;
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const transcriptPath = `${sessionDir}/transcript-${dateStr}-${id}.md`;
+  try {
+    const { mkdirSync, writeFileSync } = require("fs");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(transcriptPath, `# Session ${id}\n## Task: ${opts.task.slice(0, 200)}\n---\n`);
+  } catch {}
+
   const session: Session = {
     id,
     task: opts.task.slice(0, 500),
     cwd,
     command: `${command} ${args.slice(0, -1).join(" ")}`,
     type: "print",
+    owner: opts.owner || null,
+    labels: opts.labels || [],
     proc,
     _lastCapturedLength: 0,
     status: "running",
@@ -152,6 +176,7 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
     endedAt: null,
     output: [],
     wsClients: new Set(),
+    transcriptPath,
   };
 
   sessions.set(id, session);
@@ -243,6 +268,8 @@ export async function createInteractiveSession(
     cwd,
     command: claudeCmd,
     type: "interactive",
+    owner: opts.owner || null,
+    labels: opts.labels || [],
     tmuxName,
     transcriptPath,
     _lastCapturedLength: 0,
@@ -264,8 +291,20 @@ export async function createInteractiveSession(
 // Read
 // ---------------------------------------------------------------------------
 
-export function listSessions(): SessionInfo[] {
-  return Array.from(sessions.values()).map(toInfo);
+export function listSessions(filter?: SessionFilter): SessionInfo[] {
+  let results = Array.from(sessions.values());
+
+  if (filter?.owner) {
+    results = results.filter((s) => s.owner === filter.owner);
+  }
+  if (filter?.label) {
+    results = results.filter((s) => s.labels.includes(filter.label!));
+  }
+  if (filter?.status) {
+    results = results.filter((s) => s.status === filter.status);
+  }
+
+  return results.map(toInfo);
 }
 
 export async function getSession(id: string): Promise<SessionDetail | null> {
@@ -298,16 +337,19 @@ export async function getSession(id: string): Promise<SessionDetail | null> {
 export async function readTranscript(
   id: string,
   since?: number
-): Promise<string | null> {
+): Promise<{ text: string; offset: number; totalSize: number } | null> {
   const session = sessions.get(id);
   if (!session || !session.transcriptPath) return null;
 
   try {
     const file = Bun.file(session.transcriptPath);
-    if (!(await file.exists())) return "";
+    if (!(await file.exists())) return { text: "", offset: 0, totalSize: 0 };
     const text = await file.text();
-    if (since !== undefined && since > 0) return text.slice(since);
-    return text;
+    const totalSize = text.length;
+    if (since !== undefined && since > 0) {
+      return { text: text.slice(since), offset: since, totalSize };
+    }
+    return { text, offset: 0, totalSize };
   } catch {
     return null;
   }
@@ -334,6 +376,22 @@ export function killSession(id: string): boolean {
   }
 
   return true;
+}
+
+/**
+ * Kill all sessions matching a filter (owner, label, status).
+ * Returns the number of sessions killed.
+ */
+export function killSessionsByFilter(filter: SessionFilter): number {
+  let killed = 0;
+  for (const [id, session] of sessions) {
+    if (filter.owner && session.owner !== filter.owner) continue;
+    if (filter.label && !session.labels.includes(filter.label)) continue;
+    if (filter.status && session.status !== filter.status) continue;
+
+    if (killSession(id)) killed++;
+  }
+  return killed;
 }
 
 // ---------------------------------------------------------------------------
@@ -471,6 +529,14 @@ function streamReader(
         const text = decoder.decode(value);
         session.output.push(text);
 
+        // Tee to transcript file
+        if (session.transcriptPath) {
+          try {
+            const { appendFileSync } = require("fs");
+            appendFileSync(session.transcriptPath, text);
+          } catch {}
+        }
+
         while (session.output.length > config.outputBufferSize) {
           session.output.shift();
         }
@@ -513,5 +579,7 @@ function toInfo(session: Session): SessionInfo {
     endedAt: session.endedAt?.toISOString() || null,
     outputLines: session.output.length,
     wsClients: session.wsClients.size,
+    owner: session.owner,
+    labels: session.labels,
   };
 }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -8,6 +8,8 @@
 
 import { spawn, type Subprocess } from "bun";
 import { randomUUID } from "crypto";
+import { appendFile, mkdir, writeFile } from "fs/promises";
+import { resolve } from "path";
 import { config, presets } from "./config";
 
 // ---------------------------------------------------------------------------
@@ -118,7 +120,7 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
   }
 
   const id = randomUUID().slice(0, 8);
-  const cwd = opts.cwd || process.env.HOME || "/tmp";
+  const cwd = resolve(opts.cwd || process.env.HOME || "/tmp");
 
   let command: string;
   let args: string[];
@@ -151,14 +153,12 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
   });
 
   // Set up transcript file for print sessions too
-  const sessionDir = `${cwd}/.session`;
+  const sessionDir = resolve(cwd, ".session");
   const dateStr = new Date().toISOString().slice(0, 10);
-  const transcriptPath = `${sessionDir}/transcript-${dateStr}-${id}.md`;
-  try {
-    const { mkdirSync, writeFileSync } = require("fs");
-    mkdirSync(sessionDir, { recursive: true });
-    writeFileSync(transcriptPath, `# Session ${id}\n## Task: ${opts.task.slice(0, 200)}\n---\n`);
-  } catch {}
+  const transcriptPath = resolve(sessionDir, `transcript-${dateStr}-${id}.md`);
+  mkdir(sessionDir, { recursive: true })
+    .then(() => writeFile(transcriptPath, `# Session ${id}\n## Task: ${opts.task.slice(0, 200)}\n---\n`))
+    .catch(() => {});
 
   const session: Session = {
     id,
@@ -218,7 +218,7 @@ export async function createInteractiveSession(
   }
 
   const id = randomUUID().slice(0, 8);
-  const cwd = opts.cwd || process.env.HOME || "/tmp";
+  const cwd = resolve(opts.cwd || process.env.HOME || "/tmp");
   const tmuxName = `mp-${id}`;
 
   // Resolve command + args (strip --print if present)
@@ -240,8 +240,8 @@ export async function createInteractiveSession(
 
   // Transcript path: <cwd>/.session/transcript-<date>-<id>.md
   const dateStr = new Date().toISOString().slice(0, 10);
-  const sessionDir = `${cwd}/.session`;
-  const transcriptPath = `${sessionDir}/transcript-${dateStr}-${id}.md`;
+  const sessionDir = resolve(cwd, ".session");
+  const transcriptPath = resolve(sessionDir, `transcript-${dateStr}-${id}.md`);
 
   await Bun.$`mkdir -p ${sessionDir}`.quiet();
 
@@ -344,12 +344,10 @@ export async function readTranscript(
   try {
     const file = Bun.file(session.transcriptPath);
     if (!(await file.exists())) return { text: "", offset: 0, totalSize: 0 };
-    const text = await file.text();
-    const totalSize = text.length;
-    if (since !== undefined && since > 0) {
-      return { text: text.slice(since), offset: since, totalSize };
-    }
-    return { text, offset: 0, totalSize };
+    const totalSize = file.size;
+    const offset = Math.max(0, Math.min(Math.trunc(since ?? 0), totalSize));
+    const bytes = await file.slice(offset).arrayBuffer();
+    return { text: new TextDecoder().decode(bytes), offset, totalSize };
   } catch {
     return null;
   }
@@ -532,8 +530,7 @@ function streamReader(
         // Tee to transcript file
         if (session.transcriptPath) {
           try {
-            const { appendFileSync } = require("fs");
-            appendFileSync(session.transcriptPath, text);
+            appendFile(session.transcriptPath, text).catch(() => {});
           } catch {}
         }
 


### PR DESCRIPTION
## Summary
- consolidate maintenance PR work for config/presets, print transcripts, owner/label/status filters, and transcript offset validation
- normalize session cwd/transcript paths and avoid CommonJS fs usage in Bun ESM code
- add Bun tests for config/presets and session metadata/filter/transcript behavior

## Verification
- bun x tsc --noEmit
- bun test