### PR TITLE
feat: default MonkeyProof sessions to direct exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,38 @@ bun install
 AGENT_WS_TOKEN=your-secret-token bun run src/index.ts
 ```
 
-## Spawn a session
+## Spawn a direct exec session (default)
+
+`POST /sessions` defaults to direct shell execution (`type: "exec"`). MonkeyProof runs the `task` with `/bin/sh -lc` unless you pass an explicit `command`/`args`. This is the preferred path for normal automation and maintenance work because MonkeyProof executes the command directly instead of routing through Claude middleware.
+
+```bash
+curl -X POST http://localhost:3200/sessions \
+  -H "Authorization: Bearer your-s...ken" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "bun test",
+    "cwd": "/home/skippy/Development/king/king-dashboard"
+  }'
+```
+
+You can also be explicit:
+
+```json
+{ "type": "exec", "task": "scripts/maintenance --dry-run", "cwd": "/path/to/repo" }
+```
+
+`mode` is accepted as a backwards-compatible alias for `type`.
+
+## Spawn an agent print session
+
+Claude/Codex print sessions are still supported, but they must be requested explicitly with `type: "print"` (or `mode: "print"`).
 
 ```bash
 curl -X POST http://localhost:3200/sessions \
   -H "Authorization: Bearer your-secret-token" \
   -H "Content-Type: application/json" \
   -d '{
+    "type": "print",
     "task": "Fix the bug in auth.ts",
     "cwd": "/home/skippy/Development/king/king-dashboard",
     "command": "claude",
@@ -88,12 +113,12 @@ ws.send(JSON.stringify({ type: "stdin", data: "yes\n" }));
 
 ## Agent Presets
 
-Instead of specifying `command` + `args` every time, use presets:
+Instead of specifying `command` + `args` every time for print/interactive agent sessions, use presets and set `type`/`mode` explicitly:
 
 ```bash
 curl -X POST http://localhost:3200/sessions \
   -H "Authorization: Bearer your-secret-token" \
-  -d '{"task": "Fix the bug", "cwd": "/path/to/repo", "preset": "claude"}'
+  -d '{"type": "print", "task": "Fix the bug", "cwd": "/path/to/repo", "preset": "claude"}'
 ```
 
 Built-in presets: `claude`, `claude-sonnet`, `claude-opus`, `claude-interactive`, `claude-interactive-sonnet`, `claude-interactive-opus`, `codex`, `codex-auto`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ AGENT_WS_TOKEN=your-secret-token bun run src/index.ts
 
 ```bash
 curl -X POST http://localhost:3200/sessions \
-  -H "Authorization: Bearer your-s...ken" \
+  -H "Authorization: Bearer ***" \
   -H "Content-Type: application/json" \
   -d '{
     "task": "bun test",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ A lightweight process manager that lets an AI orchestrator (or you, monkey) spaw
 - **Auth:** Bearer token
 - **Storage:** In-memory (sessions are ephemeral)
 
+## Security
+
+MonkeyProof executes commands on the host where it runs. Bind it only on trusted networks, always set a strong `AGENT_WS_TOKEN`, and treat built-in agent presets as privileged because Claude presets include `--permission-mode bypassPermissions` for unattended work. Use direct `exec` with explicit commands when that permission mode is not appropriate.
+
 ## API
 
 ```
@@ -42,16 +46,22 @@ WS     /sessions/:id/ws       Real-time output stream + input
 
 ```bash
 bun install
-AGENT_WS_TOKEN=your-secret-token bun run src/index.ts
+AGENT_WS_TOKEN=YOUR_STRONG_SECRET bun run src/index.ts
+```
+
+All HTTP endpoints require bearer authentication:
+
+```bash
+-H "Authorization: Bearer YOUR_STRONG_SECRET"
 ```
 
 ## Spawn a direct exec session (default)
 
-`POST /sessions` defaults to direct shell execution (`type: "exec"`). MonkeyProof runs the `task` with `/bin/sh -lc` unless you pass an explicit `command`/`args`. This is the preferred path for normal automation and maintenance work because MonkeyProof executes the command directly instead of routing through Claude middleware.
+`POST /sessions` defaults to direct shell execution (`type: "exec"`). MonkeyProof runs the full `task` with `/bin/sh -lc` unless you pass an explicit `command`/`args`. This is the preferred path for normal automation and maintenance work because MonkeyProof executes the command directly instead of routing through Claude middleware.
 
 ```bash
 curl -X POST http://localhost:3200/sessions \
-  -H "Authorization: Bearer ***" \
+  -H "Authorization: Bearer YOUR_STRONG_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "task": "bun test",
@@ -65,7 +75,7 @@ You can also be explicit:
 { "type": "exec", "task": "scripts/maintenance --dry-run", "cwd": "/path/to/repo" }
 ```
 
-`mode` is accepted as a backwards-compatible alias for `type`.
+`mode` is accepted as a backwards-compatible alias for `type`. Presets are not valid for `exec` sessions; set `type: "print"` or `type: "interactive"` when using `preset`.
 
 ## Spawn an agent print session
 
@@ -73,7 +83,7 @@ Claude/Codex print sessions are still supported, but they must be requested expl
 
 ```bash
 curl -X POST http://localhost:3200/sessions \
-  -H "Authorization: Bearer your-secret-token" \
+  -H "Authorization: Bearer YOUR_STRONG_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "type": "print",
@@ -88,10 +98,11 @@ curl -X POST http://localhost:3200/sessions \
 ## Stream output via WebSocket
 
 ```javascript
-const ws = new WebSocket("ws://localhost:3200/sessions/abc123/ws?token=your-secret-token");
+const ws = new WebSocket("ws://localhost:3200/sessions/abc123/ws?token=YOUR_STRONG_SECRET");
 ws.onmessage = (e) => {
   const msg = JSON.parse(e.data);
   if (msg.type === "stdout") process.stdout.write(msg.data);
+  if (msg.type === "stderr") process.stderr.write(msg.data);
   if (msg.type === "exit") console.log(`Done: exit ${msg.code}`);
 };
 // Send stdin
@@ -109,15 +120,14 @@ ws.send(JSON.stringify({ type: "stdin", data: "yes\n" }));
 | `SESSION_TTL_MS` | `3600000` | Auto-cleanup exited sessions after (ms) |
 | `INTERACTIVE_SESSION_TTL_MS` | `7200000` | Auto-cleanup exited interactive tmux sessions after (ms) |
 
-> Built-in Claude presets include `--permission-mode bypassPermissions` for unattended agent work. Use them only in trusted workspaces, or pass explicit `command`/`args` if that permission mode is not appropriate.
-
 ## Agent Presets
 
 Instead of specifying `command` + `args` every time for print/interactive agent sessions, use presets and set `type`/`mode` explicitly:
 
 ```bash
 curl -X POST http://localhost:3200/sessions \
-  -H "Authorization: Bearer your-secret-token" \
+  -H "Authorization: Bearer YOUR_STRONG_SECRET" \
+  -H "Content-Type: application/json" \
   -d '{"type": "print", "task": "Fix the bug", "cwd": "/path/to/repo", "preset": "claude"}'
 ```
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -11,8 +11,8 @@ describe("config", () => {
     expect(config.port).toBe(3200);
   });
 
-  test("default auth token is a placeholder, not a plaintext shared secret", () => {
-    expect(config.authToken).toBe("CHANGE_ME_AGENT_WS_TOKEN");
+  test("auth token defaults to placeholder but honors environment override", () => {
+    expect(config.authToken).toBe(process.env.AGENT_WS_TOKEN || "CHANGE_ME_AGENT_WS_TOKEN");
     expect(config.authToken).not.toBe("monkeyproof-dev");
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,19 +52,21 @@ app.get("/health", (c) => c.json({ ok: true }));
 
 // ---------------------------------------------------------------------------
 // POST /sessions -- spawn a new session
-// Body: { task, mode?: "print" | "interactive", ...SessionCreateOpts }
+// Body: { task, type?: "exec" | "print" | "interactive", mode?: same, ...SessionCreateOpts }
+// Defaults to direct shell exec. Claude print/interactive modes must be explicit.
 // ---------------------------------------------------------------------------
 app.post("/sessions", async (c) => {
   try {
-    const body = await c.req.json<{ task: string; mode?: string } & Record<string, unknown>>();
+    const body = await c.req.json<{ task: string; type?: string; mode?: string } & Record<string, unknown>>();
     if (!body.task) {
       return c.json({ error: "task is required" }, 400);
     }
 
-    const mode = body.mode ?? "print";
-    if (mode !== "print" && mode !== "interactive") {
-      return c.json({ error: 'mode must be "print" or "interactive"' }, 400);
+    const mode = body.type ?? body.mode ?? "exec";
+    if (mode !== "exec" && mode !== "print" && mode !== "interactive") {
+      return c.json({ error: 'type/mode must be "exec", "print", or "interactive"' }, 400);
     }
+    body.type = mode;
 
     const session =
       mode === "interactive"
@@ -178,7 +180,7 @@ const banner = `
   GET    /sessions/:id/transcript → transcript (print + interactive)
   WS     /sessions/:id/ws         → stream
   ──────────────────────────────────────────────
-  Modes: print (default) | interactive (tmux)
+  Modes: exec (default shell command) | print (agent CLI) | interactive (tmux)
 `;
 
 console.log(banner);

--- a/src/sessions.test.ts
+++ b/src/sessions.test.ts
@@ -30,6 +30,51 @@ afterEach(async () => {
 });
 
 describe("sessions", () => {
+  test("defaults to direct exec mode and runs task through a shell", async () => {
+    const cwd = await tmpCwd();
+    const session = createSession({
+      task: "printf 'direct-exec:%s' \"$PWD\"",
+      cwd,
+    });
+
+    expect(session.type).toBe("exec");
+    expect(session.command).toContain("/bin/sh -lc");
+
+    for (let i = 0; i < 40; i++) {
+      const transcript = await readTranscript(session.id);
+      if (transcript?.text.includes("direct-exec:")) break;
+      await Bun.sleep(25);
+    }
+
+    const detail = await getSession(session.id);
+    const transcript = await readTranscript(session.id);
+    expect(detail?.status).toBe("exited");
+    expect(detail?.exitCode).toBe(0);
+    expect(transcript?.text).toContain(`direct-exec:${cwd}`);
+  });
+
+  test("explicit print mode keeps agent-style task argument behavior", async () => {
+    const cwd = await tmpCwd();
+    const session = createSession({
+      type: "print",
+      task: "print-task-arg",
+      cwd,
+      command: "bun",
+      args: ["--eval", "console.log(process.argv.at(-1))"],
+    });
+
+    expect(session.type).toBe("print");
+    expect(session.command).toBe("bun --eval console.log(process.argv.at(-1))");
+
+    for (let i = 0; i < 40; i++) {
+      const transcript = await readTranscript(session.id);
+      if (transcript?.text.includes("print-task-arg")) break;
+      await Bun.sleep(25);
+    }
+
+    expect((await readTranscript(session.id))?.text).toContain("print-task-arg");
+  });
+
   test("persists owner and labels and supports filters", async () => {
     const cwd = await tmpCwd();
     const session = createSession({

--- a/src/sessions.test.ts
+++ b/src/sessions.test.ts
@@ -20,6 +20,15 @@ async function tmpCwd(): Promise<string> {
   return dir;
 }
 
+async function waitForSessionExit(id: string) {
+  for (let i = 0; i < 80; i++) {
+    const detail = await getSession(id);
+    if (detail?.status === "exited") return detail;
+    await Bun.sleep(25);
+  }
+  return getSession(id);
+}
+
 afterEach(async () => {
   for (const session of listSessions()) {
     killSession(session.id);
@@ -73,6 +82,49 @@ describe("sessions", () => {
     }
 
     expect((await readTranscript(session.id))?.text).toContain("print-task-arg");
+  });
+
+  test("rejects presets for direct exec sessions", async () => {
+    const cwd = await tmpCwd();
+
+    expect(() =>
+      createSession({
+        task: "echo should-not-run",
+        cwd,
+        type: "exec",
+        preset: "claude",
+      }),
+    ).toThrow(/preset is only valid/);
+  });
+
+  test("preserves full task while exposing a bounded taskPreview", async () => {
+    const cwd = await tmpCwd();
+    const task = `printf done # ${"x".repeat(800)}`;
+    const session = createSession({ task, cwd });
+    const detail = await waitForSessionExit(session.id);
+    const transcript = await readTranscript(session.id);
+
+    expect(session.task).toBe(task);
+    expect(session.taskPreview).toBe(task.slice(0, 500));
+    expect(session.taskPreview.length).toBe(500);
+    expect(detail?.task).toBe(task);
+    expect(transcript?.text).toContain(task);
+  });
+
+  test("records stderr with labels and nonzero exit codes", async () => {
+    const cwd = await tmpCwd();
+    const session = createSession({
+      task: "bun --eval \"console.error('bad-news'); process.exit(7)\"",
+      cwd,
+    });
+
+    const detail = await waitForSessionExit(session.id);
+    const transcript = await readTranscript(session.id);
+
+    expect(detail?.status).toBe("exited");
+    expect(detail?.exitCode).toBe(7);
+    expect(detail?.recentOutput).toContain("[stderr] bad-news");
+    expect(transcript?.text).toContain("[stderr] bad-news");
   });
 
   test("persists owner and labels and supports filters", async () => {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,8 +1,9 @@
 /**
  * @module sessions
  * @description Session manager -- spawns, tracks, and streams coding agent processes.
- * Supports two modes:
- *   - "print": one-shot subprocess with piped stdout (original behavior)
+ * Supports three modes:
+ *   - "exec": one-shot shell command with piped stdout/stderr
+ *   - "print": one-shot subprocess with piped stdout (agent CLI behavior)
  *   - "interactive": tmux-based persistent session with live capture
  */
 
@@ -16,8 +17,12 @@ import { config, presets } from "./config";
 // Types
 // ---------------------------------------------------------------------------
 
+export type SessionType = "exec" | "print" | "interactive";
+
 export interface SessionCreateOpts {
   task: string;
+  type?: SessionType;
+  mode?: SessionType;
   cwd?: string;
   command?: string;
   args?: string[];
@@ -46,7 +51,7 @@ export interface SessionInfo {
   task: string;
   cwd: string;
   command: string;
-  type: "print" | "interactive";
+  type: SessionType;
   status: SessionStatus;
   exitCode: number | null;
   pid: number | null;
@@ -68,7 +73,7 @@ interface Session {
   task: string;
   cwd: string;
   command: string;
-  type: "print" | "interactive";
+  type: SessionType;
   owner: string | null;
   labels: string[];
   pid: number | null;
@@ -134,7 +139,12 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
   let command: string;
   let args: string[];
 
-  if (opts.preset && presets[opts.preset]) {
+  const sessionType = opts.type ?? opts.mode ?? "exec";
+
+  if (sessionType === "exec") {
+    command = opts.command || "/bin/sh";
+    args = opts.args ? [...opts.args, opts.task] : ["-lc", opts.task];
+  } else if (opts.preset && presets[opts.preset]) {
     const preset = presets[opts.preset]!;
     command = preset.command;
     args = [...preset.args];
@@ -143,11 +153,13 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
     args = opts.args || ["--print", "--permission-mode", "bypassPermissions"];
   }
 
-  if (command === "claude" && opts.maxTurns) {
+  if (sessionType !== "exec" && command === "claude" && opts.maxTurns) {
     args.push("--max-turns", String(opts.maxTurns));
   }
 
-  args.push(opts.task);
+  if (sessionType !== "exec") {
+    args.push(opts.task);
+  }
 
   const procEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),
@@ -173,8 +185,8 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
     id,
     task: opts.task.slice(0, 500),
     cwd,
-    command: `${command} ${args.slice(0, -1).join(" ")}`,
-    type: "print",
+    command: sessionType === "exec" ? `${command} ${args.join(" ")}` : `${command} ${args.slice(0, -1).join(" ")}`,
+    type: sessionType,
     owner: opts.owner || null,
     labels: normalizeLabels(opts.labels),
     pid: proc.pid ?? null,

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -49,6 +49,7 @@ export interface SessionFilter {
 export interface SessionInfo {
   id: string;
   task: string;
+  taskPreview: string;
   cwd: string;
   command: string;
   type: SessionType;
@@ -71,6 +72,7 @@ export interface SessionDetail extends SessionInfo {
 interface Session {
   id: string;
   task: string;
+  taskPreview: string;
   cwd: string;
   command: string;
   type: SessionType;
@@ -141,6 +143,10 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
 
   const sessionType = opts.type ?? opts.mode ?? "exec";
 
+  if (sessionType === "exec" && opts.preset) {
+    throw new Error('preset is only valid for type "print" or "interactive"; omit preset for exec sessions');
+  }
+
   if (sessionType === "exec") {
     command = opts.command || "/bin/sh";
     args = opts.args ? [...opts.args, opts.task] : ["-lc", opts.task];
@@ -178,12 +184,13 @@ export function createSession(opts: SessionCreateOpts): SessionInfo {
   const dateStr = new Date().toISOString().slice(0, 10);
   const transcriptPath = resolve(sessionDir, `transcript-${dateStr}-${id}.md`);
   const transcriptReady = mkdir(sessionDir, { recursive: true })
-    .then(() => writeFile(transcriptPath, `# Session ${id}\n## Task: ${opts.task.slice(0, 200)}\n---\n`))
+    .then(() => writeFile(transcriptPath, `# Session ${id}\n## Task\n\n${opts.task}\n\n---\n`))
     .catch(() => {});
 
   const session: Session = {
     id,
-    task: opts.task.slice(0, 500),
+    task: opts.task,
+    taskPreview: opts.task.slice(0, 500),
     cwd,
     command: sessionType === "exec" ? `${command} ${args.join(" ")}` : `${command} ${args.slice(0, -1).join(" ")}`,
     type: sessionType,
@@ -289,7 +296,8 @@ export async function createInteractiveSession(
 
   const session: Session = {
     id,
-    task: opts.task.slice(0, 500),
+    task: opts.task,
+    taskPreview: opts.task.slice(0, 500),
     cwd,
     command: claudeCmd,
     type: "interactive",
@@ -563,12 +571,13 @@ function streamReader(
         const { done, value } = await reader.read();
         if (done) break;
         const text = decoder.decode(value);
-        session.output.push(text);
+        const labeledText = channel === "stderr" ? `[stderr] ${text}` : text;
+        session.output.push(labeledText);
 
         // Tee to transcript file
         if (session.transcriptPath) {
           session.transcriptReady
-            ?.then(() => appendFile(session.transcriptPath!, text))
+            ?.then(() => appendFile(session.transcriptPath!, labeledText))
             .catch(() => {});
         }
 
@@ -604,6 +613,7 @@ function toInfo(session: Session): SessionInfo {
   return {
     id: session.id,
     task: session.task,
+    taskPreview: session.taskPreview,
     cwd: session.cwd,
     command: session.command,
     type: session.type,


### PR DESCRIPTION
## Summary
- default POST /sessions to direct shell exec instead of Claude print sessions
- keep Claude/Codex print and tmux interactive modes explicit via type/mode
- add tests covering exec default and explicit print behavior
- update README API examples for direct exec vs agent print sessions

## Test Plan
- AGENT_WS_TOKEN=CHANGE...OKEN bun test
- bun build src/index.ts --target bun --outdir /tmp/monkeyproof-build
- git diff --check

Note: the collab maintenance executor was also patched outside this repo to send type/mode exec for apply payloads.